### PR TITLE
Handle git clone of non-existent repos

### DIFF
--- a/github/download_repos.py
+++ b/github/download_repos.py
@@ -24,7 +24,7 @@ def clone_repo(args):
     url, output_dir = args
     org, repo = url.split('/')[-2:]
     clone_dir = os.path.join(output_dir, org, repo)
-    clone_template = 'git clone -q --depth 1 {url} {clone_dir}'
+    clone_template = 'git clone -c core.askPass=echo -q --depth 1 {url} {clone_dir}'
     if os.system(clone_template.format(url=url, clone_dir=clone_dir)) != 0:
         return url
     return None


### PR DESCRIPTION
This PR fixes issue #32.

git clone command when given a non-existent repo asks for user credentials (not
sure why). This creates problems for automated download/clone of repositories
for ControlFlag. By adding "-c core.askPass=echo" option to git clone, we can
bypass these prompts, and instead we will get a verbose error like below:

```
$ python3 download_repos.py -f failed.c100.txt -o training_repo_dir -m clone -p 1
Number of repos: 100
 19%|███████████████ | 19/100 [01:08<02:23,  1.77s/it]
remote: Support for password authentication was
removed on August 13, 2021. Please use a personal access token instead.
remote: Please see
https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/
for more information.
fatal: Authentication failed for 'https://github.com/craSH/socat/'
```