### PR TITLE
Fix the build on Windows using mingw

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,7 +45,17 @@ target_include_directories(cf_base ${COMMON_INCLUDES})
 add_executable(cf_file_scanner cf_file_scanner.cpp)
 target_include_directories(cf_file_scanner ${COMMON_INCLUDES})
 target_link_libraries(cf_file_scanner ${COMMON_LINK_LIBRARIES})
+target_link_options(cf_file_scanner PRIVATE $<$<PLATFORM_ID:Windows>:-static-libgcc -static-libstdc++ -static>)
 
 add_executable(cf_dump_code_blocks cf_dump_code_blocks.cpp)
 target_include_directories(cf_dump_code_blocks ${COMMON_INCLUDES})
 target_link_libraries(cf_dump_code_blocks ${COMMON_LINK_LIBRARIES})
+target_link_options(cf_dump_code_blocks PRIVATE $<$<PLATFORM_ID:Windows>:-static-libgcc -static-libstdc++ -static>)
+
+# To be able to use the default scripts even if we have chosen to build outside
+#  the source directory
+install(TARGETS
+          cf_file_scanner
+          cf_dump_code_blocks
+        RUNTIME           # Following options apply to runtime artifacts.
+          COMPONENT Runtime)

--- a/src/cf_dump_code_blocks.cpp
+++ b/src/cf_dump_code_blocks.cpp
@@ -100,7 +100,7 @@ int handle_command_args(int argc, char* argv[], CFDumpArgs& command_args) {
   int opt;
   while ((opt = getopt(argc, argv, "f:l:g:t:")) != -1) {
     switch (opt) {
-      case 'f': command_args.source_file_ = optarg; break;
+      case 'f': command_args.source_file_ = FormatPath(optarg); break;
       case 'l':
         command_args.source_language_ = VerifyLanguage(atoi(optarg)); break;
       case 'g':

--- a/src/cf_file_scanner.cpp
+++ b/src/cf_file_scanner.cpp
@@ -66,9 +66,9 @@ static int handle_command_args(int argc, char* argv[], FileScannerArgs& args) {
   while ((opt = getopt(argc, argv, "v:t:e:c:n:s:j:o:a:l:")) != -1) {
     switch (opt) {
       case 't': args.train_dataset_ = optarg; break;
-      case 'e': args.eval_source_file_ = optarg; break;
-      case 's': args.eval_source_file_list_ = optarg; break;
-      case 'o': args.log_dir_ = optarg; break;
+      case 'e': args.eval_source_file_ = FormatPath(optarg); break;
+      case 's': args.eval_source_file_list_ = FormatPath(optarg); break;
+      case 'o': args.log_dir_ = FormatPath(optarg); break;
       // Fixing the max cost to 2 to keep autocorrection time reasonable.
       case 'c': args.scan_config_.max_cost_ = std::max(0, atoi(optarg)); break;
       case 'n': args.scan_config_.max_autocorrections_ =
@@ -108,7 +108,7 @@ static int AddEvalFileNamesIntoList(const FileScannerArgs& file_scanner_args,
                                       file_scanner_args.eval_source_file_list_);
     }
     while (std::getline(stream, line))
-      eval_file_names.push_back(line);
+      eval_file_names.push_back(FormatPath(line));
   }
   return EXIT_SUCCESS;
 }

--- a/src/common_util.h
+++ b/src/common_util.h
@@ -32,8 +32,8 @@
 #include "parser.h"
 
 #ifdef WIN32
-#include <regex>
-typedef long long suseconds_t;
+#include <regex>  // NOLINT [build/c++11]
+typedef int64_t suseconds_t;
 inline std::string FormatPath(const std::string &filename) {
   // If the filename path comes from a bash command, translate its posix drive
   //  letter into a windows one
@@ -103,8 +103,11 @@ class Timer {
 
     suseconds_t diff_microsec = timeval2microsec(end_tv_) -
                                 timeval2microsec(start_tv_);
-    struct timeval diff_tv = {.tv_sec = static_cast<decltype(diff_tv.tv_sec)>(diff_microsec / kMicroSecs),
-                              .tv_usec = static_cast<decltype(diff_tv.tv_usec)>(diff_microsec % kMicroSecs)};
+    struct timeval diff_tv = {
+      .tv_sec  =
+        static_cast<decltype(diff_tv.tv_sec)>(diff_microsec / kMicroSecs),
+      .tv_usec =
+        static_cast<decltype(diff_tv.tv_usec)>(diff_microsec % kMicroSecs)};
     return diff_tv;
   }
 

--- a/src/common_util.h
+++ b/src/common_util.h
@@ -31,6 +31,21 @@
 
 #include "parser.h"
 
+#ifdef WIN32
+#include <regex>
+typedef long long suseconds_t;
+inline std::string FormatPath(const std::string &filename) {
+  // If the filename path comes from a bash command, translate its posix drive
+  //  letter into a windows one
+  std::regex re("^\\/([a-zA-Z])\\/");
+  return std::regex_replace(filename, re, "$1:/");
+}
+#else   // WIN32
+inline std::string FormatPath(const std::string &filename) {
+  return filename;
+}
+#endif  // WIN32
+
 //----------------------------------------------------------------------------
 
 typedef TSNode code_block_t;
@@ -88,8 +103,8 @@ class Timer {
 
     suseconds_t diff_microsec = timeval2microsec(end_tv_) -
                                 timeval2microsec(start_tv_);
-    struct timeval diff_tv = {.tv_sec = diff_microsec / kMicroSecs,
-                              .tv_usec = diff_microsec % kMicroSecs};
+    struct timeval diff_tv = {.tv_sec = static_cast<decltype(diff_tv.tv_sec)>(diff_microsec / kMicroSecs),
+                              .tv_usec = static_cast<decltype(diff_tv.tv_usec)>(diff_microsec % kMicroSecs)};
     return diff_tv;
   }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ foreach(file ${files})
       tree-sitter-cpp
       tree-sitter-verilog
       pthread)
+    target_link_options(${file_without_ext} PRIVATE $<$<PLATFORM_ID:Windows>:-static-libgcc -static-libstdc++ -static>)
     foreach(part ${${file_without_ext}_parts})
       add_test(NAME ${file_without_ext}_${part} COMMAND ${file_without_ext} ${part} WORKING_DIRECTORY ${CTEST_BINARY_DIRECTORY})
       set_tests_properties(${file_without_ext}_${part}


### PR DESCRIPTION
- static link to mingw libraries (to avoid path issues)
- adjust the path conventions (drive letter) to be able to use existing bash scripts on Windows
- add an install target to be able to build outside the source folder (and keep using existing bash scripts)